### PR TITLE
add CI test workflow with frontend coverage and artifacts

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,41 @@
+name:  CI Test
+
+on:
+  push:
+    branches: ["develop","main"]
+  workflow_dispatch:
+
+
+jobs:
+
+  #Front-end tests
+
+  front-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name:  Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 18
+
+      - name: Install front dependencies
+        run: npm ci
+        working-directory: ./front
+
+      - name: Run front-end tests with coverage
+        run: npm run test -- --watch=false --code-coverage --browsers=ChromeHeadless
+        working-directory: ./front
+
+      - name: Upload front coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: front-coverage
+          path: |
+            front/coverage/bobapp/lcov.info
+            front/coverage/bobapp/index.html
+            front/coverage/bobapp

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,4 +1,4 @@
-name:  CI Test
+name:  CI Tests
 
 on:
   push:
@@ -39,3 +39,50 @@ jobs:
             front/coverage/bobapp/lcov.info
             front/coverage/bobapp/index.html
             front/coverage/bobapp
+
+      - name: Download front coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: front-coverage
+          path: front/coverage/bobapp/
+
+  #Back-end tests
+
+  back-tests:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: Setup Java
+          uses: actions/setup-java@v3
+          with:
+            distribution: temurin
+            java-version: 17
+
+        - name: Run back-end tests + Jacoco
+          run: mvn clean verify jacoco:report
+          working-directory: ./back
+
+        - name: Upload back coverage artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: back-coverage
+            path: |
+              back/target/site/jacoco/jacoco.xml
+              back/target/site/jacoco/index.html
+              back/target/site/jacoco
+
+        - name: Upload back compiled classes
+          uses: actions/upload-artifact@v4
+          with:
+            name: back-classes
+            path: back/target/classes
+
+        - name: Download back coverage artifacts
+          uses: actions/download-artifact@v4
+          with:
+            name: back-coverage
+            path: back/target/site/jacoco/

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -40,12 +40,6 @@ jobs:
             front/coverage/bobapp/index.html
             front/coverage/bobapp
 
-      - name: Download front coverage artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: front-coverage
-          path: front/coverage/bobapp/
-
   #Back-end tests
 
   back-tests:
@@ -74,15 +68,5 @@ jobs:
               back/target/site/jacoco/jacoco.xml
               back/target/site/jacoco/index.html
               back/target/site/jacoco
-
-        - name: Upload back compiled classes
-          uses: actions/upload-artifact@v4
-          with:
-            name: back-classes
-            path: back/target/classes
-
-        - name: Download back coverage artifacts
-          uses: actions/download-artifact@v4
-          with:
-            name: back-coverage
-            path: back/target/site/jacoco/
+              
+            

--- a/front/karma.conf.js
+++ b/front/karma.conf.js
@@ -29,6 +29,7 @@ module.exports = function (config) {
       subdir: '.',
       reporters: [
         { type: 'html' },
+        { type: 'lcovonly' },
         { type: 'text-summary' }
       ]
     },
@@ -37,7 +38,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
     singleRun: false,
     restartOnFileChange: true
   });


### PR DESCRIPTION
chore(ci): add CI test workflow with frontend coverage and artifacts

- Added workflow 'ci-test' to automate frontend tests and backend tests with coverage
- Configured Karma to use ChromeHeadless and generate lcov reports
- Added artifact upload step to make coverage reports visible in GitHub Actions
